### PR TITLE
fix: li missing key on landing page

### DIFF
--- a/complete-sua-banda/src/pages/LandingPage/index.tsx
+++ b/complete-sua-banda/src/pages/LandingPage/index.tsx
@@ -132,8 +132,8 @@ export const LandingPage = () => {
         <styled.DivDevs>
           <h3>Equipe de desenvolvimento</h3>
           <styled.UlFooter>
-            {devs.map((dev) => (
-              <li>
+            {devs.map((dev, index) => (
+              <li key={index}>
                 <img src={dev.img} alt={`Imagem ${dev.name}`} />
                 <span>
                   {dev.name} -{" "}


### PR DESCRIPTION
É uma pequena correção, só pra parar de dar erro na hora do map dos nossos contatos na landing page